### PR TITLE
fix: add definition for curwin_col_off

### DIFF
--- a/lua/pretty-fold/init.lua
+++ b/lua/pretty-fold/init.lua
@@ -3,6 +3,8 @@ local wo = vim.wo
 local fn = vim.fn
 local api = vim.api
 
+ffi.cdef'int curwin_col_off(void);'
+
 local M = {
    ---Table with all 'foldtext' functions.
    foldtext = {}


### PR DESCRIPTION
Just installed the plugin and noticed the same error mentioned in #2. 
I got it fixed by adding definition for curwin_col_off. 
Got the line from here - https://github.com/lewis6991/cleanfold.nvim/blob/master/lua/cleanfold.lua#L7.  

Great plugin, nothing like it, thank you!