### PR TITLE
fix #16, make counts work for h/l motions

### DIFF
--- a/lua/pretty-fold/preview.lua
+++ b/lua/pretty-fold/preview.lua
@@ -173,7 +173,7 @@ function M.keymap_open_close(key)
          fn.timer_start(1, _G.pretty_fold_preview[bufnr].close)
       end
    else
-      api.nvim_command('normal! '..key)
+      api.nvim_command('normal! '..vim.v.count1..key)
    end
 end
 
@@ -188,7 +188,7 @@ function M.keymap_close(key)
    elseif fn.foldclosed('.') ~= -1 then
       api.nvim_command('normal! zv')
    else
-      api.nvim_command('normal! '..key)
+      api.nvim_command('normal! '..vim.v.count1..key)
    end
 end
 


### PR DESCRIPTION
Sorry for double opening an issue/PR, but I couldn't leave it be and it turned out to be an easy fix.

I don't think it breaks anything the plugin does or otherwise interferes in any way. As per docs, count1 should always contain a `1`, so this will affect the base use case in so far that `1h` or `1l` is run from now on, but it is sufficient to make countable motions (`42l`) work. It does also work when used as a text object, i.e. `d42l` or something, but I'm not exactly sure why and that may warrant further testing...