### PR TITLE
Safeguard closing of preview windows to avoid "Invalid window id" errors.

### DIFF
--- a/lua/pretty-fold/preview.lua
+++ b/lua/pretty-fold/preview.lua
@@ -134,6 +134,10 @@ function M.show_preview()
    wo[winid].signcolumn = 'no'
 
    function M.service_functions.close()
+      -- close() can be called multiple times for the same window.
+      if not api.nvim_win_is_valid(winid) then
+         return
+      end
       api.nvim_win_close(winid, false)
       api.nvim_buf_delete(bufnr, {force = true, unload = false})
       M.service_functions = {}


### PR DESCRIPTION
Currently, `close()` for the same preview window can be called multiple times (e.g., due to both autocmds and key mappings?), which leads to "Invalid window id" errors.
This PR prevents it by safeguarding the `close()` function.

Please consider merging this.
