### PR TITLE
fix: remove non-existant function from deep_pesc

### DIFF
--- a/lua/pretty-fold/util.lua
+++ b/lua/pretty-fold/util.lua
@@ -75,7 +75,7 @@ function util.deep_pesc(ts)
       if type(s) == 'string' then
          escaped_ts[i] = vim.pesc(s)
       elseif type(s) == 'table' then
-         escaped_ts[i] = util.escape_lua_patterns(s)
+         escaped_ts[i] = util.deep_pesc(s)
       end
    end
    return escaped_ts


### PR DESCRIPTION
looks like `escape_lua_patterns` was missed in a previous refactor